### PR TITLE
Field specifiers

### DIFF
--- a/collection-views-tests.js
+++ b/collection-views-tests.js
@@ -1,32 +1,32 @@
 // findOne() should only return documents which match both queries
-Tinytest.add('where - findOne - t1', function (test) {
+Tinytest.add('CollectionViews - findOne - t1', function (test) {
   var Books = newCollection();
   var doc = Books.where({ kind: 'book' }).findOne({ genre: 'fiction' });
   test.matches(doc.title, /Fiction Book/);
 });
 
-Tinytest.add('where - findOne - t2', function (test) {
+Tinytest.add('CollectionViews - findOne - t2', function (test) {
   var Books = newCollection();
   var doc = Books.where({ genre: 'science' }).findOne({ kind: 'magazine' });
   test.equal(doc.title, 'Science Magazine 1');
 });
 
 // find() should only return documents which match both queries
-Tinytest.add('where - find - t1', function (test) {
+Tinytest.add('CollectionViews - find - t1', function (test) {
   var Books = newCollection();
   var docs = Books.where({ kind: 'book' }).find({ genre: 'fiction' }).fetch();
   test.equal(_.pluck(docs, 'title'), ['Fiction Book 1', 'Fiction Book 2'])
   test.length(docs, 2);
 });
 
-Tinytest.add('where - find - t2', function (test) {
+Tinytest.add('CollectionViews - find - t2', function (test) {
   var Books = newCollection();
   var docs = Books.where({ genre: 'science' }).find({}).fetch();
   test.equal(_.pluck(docs, 'title'), ['Science Book 1', 'Science Magazine 1'])
   test.length(docs, 2);
 });
 
-Tinytest.add('where - find - t3 (query can be a function)', function (test) {
+Tinytest.add('CollectionViews - find - t3 (query can be a function)', function (test) {
   var Books = newCollection();
   var docs = Books.where(function () {
     return { kind: 'book' }
@@ -35,7 +35,7 @@ Tinytest.add('where - find - t3 (query can be a function)', function (test) {
   test.length(docs, 2);
 });
 
-Tinytest.add('where - find - t4 (chaining 2 where methods)', function (test) {
+Tinytest.add('CollectionViews - find - t4 (chaining 2 where methods)', function (test) {
   var Books = newCollection();
   var docs = Books
     .where({ kind: 'book' })
@@ -46,7 +46,7 @@ Tinytest.add('where - find - t4 (chaining 2 where methods)', function (test) {
   test.length(docs, 2);
 });
 
-Tinytest.add('where - find - t5 (chaining 3 where methods)', function (test) {
+Tinytest.add('CollectionViews - find - t5 (chaining 3 where methods)', function (test) {
   var Books = newCollection();
   var docs = Books
     .where({ kind: 'leaflet' })
@@ -58,7 +58,7 @@ Tinytest.add('where - find - t5 (chaining 3 where methods)', function (test) {
   test.length(docs, 1);
 });
 
-Tinytest.add('where - find - t6 (chaining 2 where methods with find query)', function (test) {
+Tinytest.add('CollectionViews - find - t6 (chaining 2 where methods with find query)', function (test) {
   var Books = newCollection();
   var docs = Books
     .where({ kind: 'leaflet' })
@@ -70,7 +70,7 @@ Tinytest.add('where - find - t6 (chaining 2 where methods with find query)', fun
 });
 
 // update() should only affect documents which match both queries
-Tinytest.add('where - update - t1', function (test) {
+Tinytest.add('CollectionViews - update - t1', function (test) {
   var Books = newCollection();
   var affectedCount = Books.where({ kind: 'book' }).update({}, 
     { $set: { catalogId: 1 } }
@@ -79,7 +79,7 @@ Tinytest.add('where - update - t1', function (test) {
   test.equal(affectedCount, 3);
 });
 
-Tinytest.add('where - update - t2', function (test) {
+Tinytest.add('CollectionViews - update - t2', function (test) {
   var Books = newCollection();
   var affectedCount = Books.where({ genre: 'fiction' }).update({ kind: 'book' }, 
     { $set: { catalogId: 1 } }
@@ -88,7 +88,7 @@ Tinytest.add('where - update - t2', function (test) {
   test.equal(affectedCount, 2);
 });
 
-Tinytest.add('where - update - t3', function (test) {
+Tinytest.add('CollectionViews - update - t3', function (test) {
   var Books = newCollection();
   var docs = Books.where({ genre: 'science', kind: 'magazine' }).find({}).fetch();
   test.length(docs, 1);
@@ -103,7 +103,7 @@ Tinytest.add('where - update - t3', function (test) {
   test.length(docs, 0);
 });
 
-Tinytest.add('where - update - t4 (chaining where methods)', function (test) {
+Tinytest.add('CollectionViews - update - t4 (chaining where methods)', function (test) {
   var Books = newCollection();
   var docs = Books
     .where({ genre: 'science' })
@@ -125,7 +125,7 @@ Tinytest.add('where - update - t4 (chaining where methods)', function (test) {
   test.length(docs, 2);
 });
 
-Tinytest.add('where - update - t5 (lazy resolving when argument is function)', function (test) {
+Tinytest.add('CollectionViews - update - t5 (lazy resolving when argument is function)', function (test) {
   var Books = newCollection();
   var docs = Books
     .where({ genre: 'science' })
@@ -156,7 +156,7 @@ Tinytest.add('where - update - t5 (lazy resolving when argument is function)', f
 });
 
 // remove() should only affect documents which match both queries
-Tinytest.add('where - remove - t1', function (test) {
+Tinytest.add('CollectionViews - remove - t1', function (test) {
   var Books = newCollection();
   var docs = Books.where({ genre: 'removable' }).find({}).fetch();
   test.length(docs, 4);
@@ -168,7 +168,7 @@ Tinytest.add('where - remove - t1', function (test) {
   test.length(docs, 2);
 });
 
-Tinytest.add('where - remove - t2 (chaining where methods)', function (test) {
+Tinytest.add('CollectionViews - remove - t2 (chaining where methods)', function (test) {
   var Books = newCollection();
   var docs = Books.where({ genre: 'cooking' }).find({}).fetch();
   test.length(docs, 3);
@@ -184,7 +184,7 @@ Tinytest.add('where - remove - t2 (chaining where methods)', function (test) {
   test.length(docs, 2);
 });
 
-Tinytest.add('where - remove - t3 (lazy resolving when argument is function)', function (test) {
+Tinytest.add('CollectionViews - remove - t3 (lazy resolving when argument is function)', function (test) {
   var Books = newCollection();
   var docs = Books.where({ genre: 'cooking' }).find({}).fetch();
   test.length(docs, 3);
@@ -206,7 +206,7 @@ Tinytest.add('where - remove - t3 (lazy resolving when argument is function)', f
 });
 
 // upsert() should only affect documents which match both queries
-Tinytest.add('where - upsert - t1', function (test) {
+Tinytest.add('CollectionViews - upsert - t1', function (test) {
   var Books = newCollection();
   var result = Books.where({ kind: 'magazine' }).upsert({}, 
     { $set: { catalogId: 1 } }
@@ -215,7 +215,7 @@ Tinytest.add('where - upsert - t1', function (test) {
   test.equal(result.numberAffected, 2);
 });
 
-Tinytest.add('where - upsert - t2 (chainable where methods)', function (test) {
+Tinytest.add('CollectionViews - upsert - t2 (chainable where methods)', function (test) {
   var Books = newCollection();
   var result = Books
     .where({ kind: 'book' })
@@ -227,7 +227,7 @@ Tinytest.add('where - upsert - t2 (chainable where methods)', function (test) {
   test.equal(result.numberAffected, 2);
 });
 
-Tinytest.add('where - upsert - t3 (lazy resolving when argument is function)', function (test) {
+Tinytest.add('CollectionViews - upsert - t3 (lazy resolving when argument is function)', function (test) {
   var Books = newCollection();
   var result = Books
     .where(function () {
@@ -243,7 +243,7 @@ Tinytest.add('where - upsert - t3 (lazy resolving when argument is function)', f
   test.equal(result.numberAffected, 1);
 });
 
-Tinytest.add('where - upsert - t4 (no matches found, insert still works)', function (test) {
+Tinytest.add('CollectionViews - upsert - t4 (no matches found, insert still works)', function (test) {
   var Books = newCollection();
   var result = Books
     .where({ kind: 'impossible' })
@@ -259,7 +259,7 @@ Tinytest.add('where - upsert - t4 (no matches found, insert still works)', funct
 });
 
 // Test if field specifiers work properly
-Tinytest.add('where - field specifiers - t1 (one specifier: only fetch the title)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t1 (one specifier: only fetch the title)', function (test) {
   var Books = newCollection();
   var doc = Books
     .where({ genre: 'science' }, { title: 1 })
@@ -274,23 +274,22 @@ Tinytest.add('where - field specifiers - t1 (one specifier: only fetch the title
   test.equal(typeof doc._id, 'string');
 });
 
-Tinytest.add('where - field specifiers - t2 (two chained specifiers: only fetch the title and the kind)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t2 (two chained specifiers: only fetch the _id)', function (test) {
   var Books = newCollection();
   var doc = Books
     .where({}, { title: 1 })
     .where({ genre: 'science' }, { kind: 1 })
     .findOne({ kind: 'magazine' });
-  test.equal(doc.title, 'Science Magazine 1');
-  test.isNotUndefined(doc.title);
+  test.isUndefined(doc.title);
   test.isUndefined(doc.genre);
-  test.isNotUndefined(doc.kind);
+  test.isUndefined(doc.kind);
   test.isUndefined(doc.catalogId);
   test.isNotUndefined(doc._id);
   test.isNotNull(doc._id);
   test.equal(typeof doc._id, 'string');
 });
 
-Tinytest.add('where - field specifiers - t3 (one specifier: remove the title)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t3 (one specifier: remove the title)', function (test) {
   var Books = newCollection();
   var doc = Books
     .where({ genre: 'science' }, { title: 0 })
@@ -304,22 +303,17 @@ Tinytest.add('where - field specifiers - t3 (one specifier: remove the title)', 
   test.equal(typeof doc._id, 'string');
 });
 
-Tinytest.add('where - field specifiers - t4 (two specifier: remove the kind and catalogId)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t4 (two specifier: remove the kind and genre)', function (test) {
   var Books = newCollection();
-  var doc = Books
-    .where({ genre: 'science' }, { kind: 0 })
-    .where({}, { catalogId: 0 })
-    .findOne({ kind: 'magazine' });
-  test.isNotUndefined(doc.title);
-  test.isNotUndefined(doc.genre);
-  test.isUndefined(doc.kind);
-  test.isUndefined(doc.catalogId);
-  test.isNotUndefined(doc._id);
-  test.isNotNull(doc._id);
-  test.equal(typeof doc._id, 'string');
+  var hideKindAndGenre = Books.where({}, { kind: 0 }).where({}, { genre: 0 });
+  test.equal(hideKindAndGenre.find().count(), Books.find().count());
+  test.isUndefined(hideKindAndGenre.findOne().kind);
+  test.isUndefined(hideKindAndGenre.findOne().genre);
+  var book = Books.findOne();
+  test.equal(hideKindAndGenre.findOne(book._id), _.omit(book, 'kind', 'genre'));
 });
 
-Tinytest.add('where - field specifiers - t5 (two specifiers: only fetch the title)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t5 (two specifiers: only fetch the title)', function (test) {
   var Books = newCollection();
   var doc = Books
     .where({ genre: 'science' }, { catalogId: 0 })
@@ -335,20 +329,45 @@ Tinytest.add('where - field specifiers - t5 (two specifiers: only fetch the titl
   test.equal(typeof doc._id, 'string');
 });
 
-Tinytest.add('where - field specifiers - t5 (two specifiers: only fetch the title and genre)', function (test) {
+Tinytest.add('CollectionViews - field specifiers - t6 (two specifiers: the second one must override the first)', function (test) {
   var Books = newCollection();
   var doc = Books
-    .where({ genre: 'science' }, { genre: 1 })
-    .where({}, { title: 1 })
+    .where({}, { genre: 1, title: 1 })
+    .where({}, { genre: 1 })
     .findOne({ kind: 'magazine' });
-  test.equal(doc.title, 'Science Magazine 1');
-  test.isNotUndefined(doc.title);
+  test.isUndefined(doc.title);
   test.isNotUndefined(doc.genre);
   test.isUndefined(doc.kind);
   test.isUndefined(doc.catalogId);
   test.isNotUndefined(doc._id);
   test.isNotNull(doc._id);
   test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('CollectionViews - field specifiers - t7 (two specifiers: the second one is passed to findOne)', function (test) {
+  var Books = newCollection();
+  var hideKindAndGenre = Books.where({}, { kind: 0 }).where();
+  test.equal(hideKindAndGenre.find({}, { fields: { genre: 0 } }).count(), Books.find().count());
+  test.isUndefined(hideKindAndGenre.findOne({}, { fields: { genre: 0 } }).kind);
+  test.isUndefined(hideKindAndGenre.findOne({}, { fields: { title: 0 } }).title);
+  var book = Books.findOne({}, { fields: { catalogId: 0 } });
+  test.equal(hideKindAndGenre.findOne(book._id, { fields: { catalogId: 0 } }), _.omit(book, 'kind', 'catalogId'));
+
+});
+
+Tinytest.add('CollectionViews - field specifiers - t8 (two specifiers: the second one is passed to find)', function (test) {
+  var Books = newCollection();
+  var docs = Books
+    .where({}, { genre: 1 })
+    .find({ kind: 'magazine' }, { fields: { genre: 1, title: 1 } })
+    .fetch();
+  test.isUndefined(docs[0].title);
+  test.isNotUndefined(docs[0].genre);
+  test.isUndefined(docs[0].kind);
+  test.isUndefined(docs[0].catalogId);
+  test.isNotUndefined(docs[0]._id);
+  test.isNotNull(docs[0]._id);
+  test.equal(typeof docs[0]._id, 'string');
 });
 
 function newCollection () {

--- a/collection-views-tests.js
+++ b/collection-views-tests.js
@@ -258,6 +258,99 @@ Tinytest.add('where - upsert - t4 (no matches found, insert still works)', funct
   test.equal(typeof result.insertedId, 'string');
 });
 
+// Test if field specifiers work properly
+Tinytest.add('where - field specifiers - t1 (one specifier: only fetch the title)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({ genre: 'science' }, { title: 1 })
+    .findOne({ kind: 'magazine' });
+  test.equal(doc.title, 'Science Magazine 1');
+  test.isNotUndefined(doc.title);
+  test.isUndefined(doc.genre);
+  test.isUndefined(doc.kind);
+  test.isUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('where - field specifiers - t2 (two chained specifiers: only fetch the title and the kind)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({}, { title: 1 })
+    .where({ genre: 'science' }, { kind: 1 })
+    .findOne({ kind: 'magazine' });
+  test.equal(doc.title, 'Science Magazine 1');
+  test.isNotUndefined(doc.title);
+  test.isUndefined(doc.genre);
+  test.isNotUndefined(doc.kind);
+  test.isUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('where - field specifiers - t3 (one specifier: remove the title)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({ genre: 'science' }, { title: 0 })
+    .findOne({ kind: 'magazine' });
+  test.isUndefined(doc.title);
+  test.isNotUndefined(doc.genre);
+  test.isNotUndefined(doc.kind);
+  test.isNotUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('where - field specifiers - t4 (two specifier: remove the kind and catalogId)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({ genre: 'science' }, { kind: 0 })
+    .where({}, { catalogId: 0 })
+    .findOne({ kind: 'magazine' });
+  test.isNotUndefined(doc.title);
+  test.isNotUndefined(doc.genre);
+  test.isUndefined(doc.kind);
+  test.isUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('where - field specifiers - t5 (two specifiers: only fetch the title)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({ genre: 'science' }, { catalogId: 0 })
+    .where({}, { title: 1 })
+    .findOne({ kind: 'magazine' });
+  test.equal(doc.title, 'Science Magazine 1');
+  test.isNotUndefined(doc.title);
+  test.isUndefined(doc.genre);
+  test.isUndefined(doc.kind);
+  test.isUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
+Tinytest.add('where - field specifiers - t5 (two specifiers: only fetch the title and genre)', function (test) {
+  var Books = newCollection();
+  var doc = Books
+    .where({ genre: 'science' }, { genre: 1 })
+    .where({}, { title: 1 })
+    .findOne({ kind: 'magazine' });
+  test.equal(doc.title, 'Science Magazine 1');
+  test.isNotUndefined(doc.title);
+  test.isNotUndefined(doc.genre);
+  test.isUndefined(doc.kind);
+  test.isUndefined(doc.catalogId);
+  test.isNotUndefined(doc._id);
+  test.isNotNull(doc._id);
+  test.equal(typeof doc._id, 'string');
+});
+
 function newCollection () {
   var Books = new Mongo.Collection(null);
   Books.remove({});

--- a/collection-views.js
+++ b/collection-views.js
@@ -76,12 +76,12 @@ CollectionView = function (sourceCollection) {
  * @param {Object | Function} query A query object or function used to filter the results of a collection operation
  * @return {Object} The narrowed collection view object
  */
-Mongo.Collection.prototype.where = CollectionView.prototype.where = function (query, fields) {
+Mongo.Collection.prototype.where = CollectionView.prototype.where = function (query, options) {
   var sourceCollection = this;
   var collectionView = new CollectionView(sourceCollection);
   collectionView._narrowingQuery = { query: query };
-  if (! _.isUndefined(fields))
-    collectionView._narrowingOptions = { fields: fields };
+  if (! _.isUndefined(options))
+    collectionView._narrowingOptions = options;
   return collectionView;
 };
 
@@ -181,7 +181,10 @@ CollectionView.prototype._mutateOptions = function (options) {
     });
   }
 
-  // The fields have been narrowed to only show the _id; this must be set explicitly
+  // The fields have been narrowed completely, however meteor/mongo treat an
+  // empty fields object as explicitly allowing everything, so we should
+  // explicitly set the _id field to 1 to signal meteor/mongo to return only
+  // the id field.
   if (narrowedFields && _.isEmpty(options.fields))
     options.fields = { _id: 1 }
 

--- a/collection-views.js
+++ b/collection-views.js
@@ -71,7 +71,8 @@ Mongo.Collection.prototype.where = CollectionView.prototype.where = function (qu
   var sourceCollection = this;
   var collectionView = new CollectionView(sourceCollection);
   collectionView._narrowingQuery = { query: query };
-  collectionView._narrowingOptions = { fields: fields };
+  if (! _.isUndefined(fields))
+    collectionView._narrowingOptions = { fields: fields };
   return collectionView;
 };
 
@@ -133,8 +134,14 @@ CollectionView.prototype._mutateOptions = function (options) {
 
   while (collection) {
     if (! _.isUndefined(collection._narrowingOptions)) {
-      _.extend(options, collection._narrowingOptions);
+      _.each(collection._narrowingOptions, function (val, key) {
+        if (! _.isUndefined(options[key]))
+          _.extend(options[key], val);
+        else
+          options[key] = val;
+      });
     }
+    
     collection = collection._parentCollection;
   }
 

--- a/collection-views.js
+++ b/collection-views.js
@@ -53,6 +53,15 @@ CollectionView = function (sourceCollection) {
     self[key] = function (selector) {
       var args = _.toArray(arguments);
       args[0] = self._mutateSelector(selector);
+
+      // Warn the developer if field specifier is detected
+      var narrowingOptions = self._mutateOptions();
+      _.each(narrowingOptions, function (val, argKey) {
+        if (argKey == 'fields') {
+          console.warn('Passing a "fields" argument has not effect on the "' + key + '" method!');
+        }
+      });
+
       return self._mongoCollection[key].apply(self._mongoCollection, args);
     };
   });

--- a/collection-views.js
+++ b/collection-views.js
@@ -58,7 +58,7 @@ CollectionView = function (sourceCollection) {
       var narrowingOptions = self._mutateOptions();
       _.each(narrowingOptions, function (val, argKey) {
         if (argKey == 'fields') {
-          console.warn('Passing a "fields" argument has not effect on the "' + key + '" method!');
+          console.warn('Passing a "fields" argument has no effect on the "' + key + '" method!');
         }
       });
 

--- a/collection-views.js
+++ b/collection-views.js
@@ -154,5 +154,19 @@ CollectionView.prototype._mutateOptions = function (options) {
     collection = collection._parentCollection;
   }
 
+  // mix including and excluding fields
+  var removeExcludingFields = !! _.find(options.fields, function(val, key) {
+    if (val === 1) {
+      return true;
+    }
+  });
+
+  if (removeExcludingFields) {
+    _.each(options.fields, function (val, key) {
+      if (val === 0)
+        delete options.fields[key];
+    });
+  }
+
   return options;
 };

--- a/collection-views.js
+++ b/collection-views.js
@@ -45,11 +45,6 @@ CollectionView = function (sourceCollection) {
       selector = self._mutateSelector(selector);
       options = self._mutateOptions(options);
 
-      console.log(selector)
-      console.log(options)
-      console.log(callback)
-      console.log("==========================")
-
       return self._mongoCollection[key](selector, options, callback);
     };
   });


### PR DESCRIPTION
Adds the ability to specify which fields should be returned for the result via the where method

Examples:

`Books.where({}, { title: 1 })` only returns the `title` and `_id` properties and
`Books.where({}, { title: 0 })` returns all properties except `title`

These field specifiers can be combined in chained `where` calls like so:

`Books.where({}, { name: -1 }).where({}, { someField: 1 })`

closes #4 
